### PR TITLE
Make travis build the client for both pull requests and master deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,14 @@ language: node_js
 node_js:
   - 8.4.0
 
-script:
-  - "npm run lint"
-  - "npm test"
+cache:
+  directories:
+    - node_modules
 
-before_deploy:
-  - "npm run build"
+script:
+  - npm run lint
+  - npm test
+  - npm run build
 
 deploy:
   - provider: script


### PR DESCRIPTION
This PR closes #86

#### What does this PR do?

- Runs the build step on both pull requests and on master. This is necessary so we don't have the build fail only on master.
- Adds caching of node_modules to speed up future builds

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/nXxOjZrbnbRxS/giphy.gif)
