### PR TITLE
Add initial graphql schema type for projects

### DIFF
--- a/server/types.graphql
+++ b/server/types.graphql
@@ -32,3 +32,19 @@ type User @model {
 #   # Every relation also required a back-relation (to determine 1:1, 1:n or n:m)
 #   author: User! @relation(name: "UserPosts")
 # }
+
+type Project @model {
+  # Required system field:
+  id: ID! @isUnique # read-only (managed by Graphcool)
+
+  # Optional system fields (remove if not needed):
+  createdAt: DateTime! # read-only (managed by Graphcool)
+  updatedAt: DateTime! # read-only (managed by Graphcool)
+
+  name: String!
+  description: String
+  repo: String #url
+  flow: String #url
+  waffleBoard: String #url
+  driveDirectory: String #url
+}


### PR DESCRIPTION
#### What does this PR do?

Adds an initial graphql type to graphcool for projects. This can easily be extended in the future, but is going to be more complicated if we need to migrate things so let's discuss different use cases now before we merge this.

#### Please Check
- typos
- naming is intuitive and makes sense
- flexible enough to support future use cases

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/l2QEbrEQECr3FIaSQ/giphy.gif)
