### PR TITLE
Add routes for user who is not logged in and corresponding test

### DIFF
--- a/src/LoggedOutRoutes.js
+++ b/src/LoggedOutRoutes.js
@@ -6,6 +6,9 @@ import NoMatchPage from './pages/NoMatchPage';
 const LoggedOutRoutes = () => (
   <Switch>
     <Route exact path="/" component={LandingPage} />;
+    <Route path="/projects" component={LandingPage} />;
+    <Route path="/volunteers" component={LandingPage} />;
+    <Route path="/me" component={LandingPage} />;
     <Route component={NoMatchPage} />
   </Switch>
 );

--- a/src/__tests__/routing.test.js
+++ b/src/__tests__/routing.test.js
@@ -4,9 +4,39 @@ import App from '../App';
 
 describe('when not logged in', () => {
   describe('when trying to navigate to /volunteers', () => {
-    it('shows the 404 page', () => {
+    it('shows the landing page w/prompt to log in', () => {
       const wrapper = mountWithContext(<App />, {
         routes: ['/volunteers']
+      });
+
+      expect(wrapper.contains('Please sign up or log in')).toBe(true);
+    });
+  });
+
+  describe('when trying to navigate to /projects', () => {
+    it('shows the landing page w/prompt to log in', () => {
+      const wrapper = mountWithContext(<App />, {
+        routes: ['/projects']
+      });
+
+      expect(wrapper.contains('Please sign up or log in')).toBe(true);
+    });
+  });
+
+  describe('when trying to navigate to /me', () => {
+    it('shows the landing page w/prompt to log in', () => {
+      const wrapper = mountWithContext(<App />, {
+        routes: ['/me']
+      });
+
+      expect(wrapper.contains('Please sign up or log in')).toBe(true);
+    });
+  });
+
+  describe('when trying to navigate to a non-existent page', () => {
+    it('shows the 404 not found page', () => {
+      const wrapper = mountWithContext(<App />, {
+        routes: ['/foobar']
       });
 
       expect(wrapper.contains('404')).toBe(true);


### PR DESCRIPTION
This PR closes no active issue, it only allows this developer to contribute for a first time with something he felt comfortable doing in React

#### What does this PR do?
It directs a user who isn't logged in to our current log in page when they try to access an internal page (currently: /projects, /me, /volunteers)

#### Feedback
Feedback is very welcome.

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)


