### PR TITLE
Fix website in microsoft edge via fetch-headers polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3018,6 +3018,12 @@
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.0.0.tgz",
           "integrity": "sha1-mCu6Q+zU8pIqKcwYamu7C7c/y6Y=",
           "dev": true
+        },
+        "whatwg-fetch": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+          "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
+          "dev": true
         }
       }
     },
@@ -4983,11 +4989,6 @@
         "pend": "~1.2.0"
       }
     },
-    "fetch-headers": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fetch-headers/-/fetch-headers-2.0.0.tgz",
-      "integrity": "sha1-urdTHDmz1y0hrBifF5dW8IVBz1U="
-    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -5267,7 +5268,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.1.1",
@@ -5341,6 +5343,7 @@
           "version": "2.10.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -5357,7 +5360,8 @@
         "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -5374,12 +5378,14 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -5392,12 +5398,14 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "cryptiles": {
           "version": "2.0.5",
@@ -5443,7 +5451,8 @@
         "delayed-stream": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -5469,7 +5478,8 @@
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -5603,7 +5613,8 @@
         "hoek": {
           "version": "2.16.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "http-signature": {
           "version": "1.1.1",
@@ -5640,6 +5651,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5653,7 +5665,8 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -5726,12 +5739,14 @@
         "mime-db": {
           "version": "1.27.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "mime-db": "~1.27.0"
           }
@@ -5805,7 +5820,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -5863,7 +5879,8 @@
         "process-nextick-args": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -5901,6 +5918,7 @@
           "version": "2.2.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -5952,7 +5970,8 @@
         "safe-buffer": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.3.0",
@@ -6010,6 +6029,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6020,6 +6040,7 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -6034,6 +6055,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6103,7 +6125,8 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -12465,11 +12488,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -12486,7 +12511,8 @@
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
@@ -12615,6 +12641,7 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -12916,6 +12943,11 @@
           "requires": {
             "ansi-regex": "^3.0.0"
           }
+        },
+        "whatwg-fetch": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+          "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
         }
       }
     },
@@ -15953,7 +15985,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -15971,11 +16004,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -15988,15 +16023,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -16099,7 +16137,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -16109,6 +16148,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -16121,6 +16161,7 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -16132,6 +16173,7 @@
             "minipass": {
               "version": "2.2.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -16220,7 +16262,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -16230,6 +16273,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -16305,7 +16349,8 @@
             },
             "safe-buffer": {
               "version": "5.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -16335,6 +16380,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -16352,6 +16398,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -16390,11 +16437,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -17724,9 +17773,9 @@
       }
     },
     "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "whatwg-url": {
       "version": "4.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4983,6 +4983,11 @@
         "pend": "~1.2.0"
       }
     },
+    "fetch-headers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fetch-headers/-/fetch-headers-2.0.0.tgz",
+      "integrity": "sha1-urdTHDmz1y0hrBifF5dW8IVBz1U="
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "auth0-js": "^9.7.3",
     "babel-polyfill": "^6.26.0",
     "date-fns": "^1.29.0",
-    "fetch-headers": "^2.0.0",
     "graphql": "^0.13.1",
     "graphql-tag": "^2.8.0",
     "marked": "^0.3.16",
@@ -27,7 +26,8 @@
     "react-router-dom": "^4.2.2",
     "react-scripts": "^1.1.5",
     "react-select": "^2.0.0",
-    "react-testing-library": "^4.1.3"
+    "react-testing-library": "^4.1.3",
+    "whatwg-fetch": "^3.0.0"
   },
   "lint-staged": {
     "{src,bin,server/src}/**/*.{js,json,css,graphql}": [

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "auth0-js": "^9.7.3",
     "babel-polyfill": "^6.26.0",
     "date-fns": "^1.29.0",
+    "fetch-headers": "^2.0.0",
     "graphql": "^0.13.1",
     "graphql-tag": "^2.8.0",
     "marked": "^0.3.16",

--- a/src/config/polyfills.js
+++ b/src/config/polyfills.js
@@ -1,3 +1,12 @@
-global.Headers = require('fetch-headers');
+import Headers from 'fetch-headers';
+
 // This is necessary for IE / Microsoft Edge because of a problem with apollo-link-rest
 // https://github.com/apollographql/apollo-link-rest/issues/93
+window.Headers = Headers;
+
+// The polyfill doesn't provide a forEach function which apollo rest uses
+window.Headers.prototype.forEach = function(fn) {
+  for (let [key, value] of this.entries()) {
+    fn(value, key, this);
+  }
+};

--- a/src/config/polyfills.js
+++ b/src/config/polyfills.js
@@ -1,12 +1,1 @@
-import Headers from 'fetch-headers';
-
-// This is necessary for IE / Microsoft Edge because of a problem with apollo-link-rest
-// https://github.com/apollographql/apollo-link-rest/issues/93
-window.Headers = Headers;
-
-// The polyfill doesn't provide a forEach function which apollo rest uses
-window.Headers.prototype.forEach = function(fn) {
-  for (let [key, value] of this.entries()) {
-    fn(value, key, this);
-  }
-};
+import 'whatwg-fetch';

--- a/src/config/polyfills.js
+++ b/src/config/polyfills.js
@@ -1,0 +1,3 @@
+global.Headers = require('fetch-headers');
+// This is necessary for IE / Microsoft Edge because of a problem with apollo-link-rest
+// https://github.com/apollographql/apollo-link-rest/issues/93

--- a/src/createApolloClient.js
+++ b/src/createApolloClient.js
@@ -35,7 +35,10 @@ const restLink = new RestLink({
   endpoints: {
     github: 'https://api.github.com/'
   },
-  credentials: 'omit'
+  credentials: 'omit',
+  headers: {
+    'Content-Type': 'application/json'
+  }
 });
 
 export default function createApolloClient() {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import 'babel-polyfill';
+import './config/polyfills';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { ApolloProvider } from 'react-apollo';


### PR DESCRIPTION
This PR closes #255 

#### What does this PR do?
This PR adds the fetch-headers polyfill to fix Apollo-link-rest in Microsoft Edge. This isn't an ideal solution because it polyfills regardless of browser support, but Microsoft Edge has the wrong fetch-headers and it is incompatible with Apollo-link-rest. For more details: see https://github.com/apollographql/apollo-link-rest/issues/93.

Importantly, however, it fixes the website in Microsoft Edge.

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/JMV7IKoqzxlrW/giphy.gif)
