### PR TITLE
Fix link to github from project cards

### DIFF
--- a/src/authenticated/project/ProjectCard.js
+++ b/src/authenticated/project/ProjectCard.js
@@ -35,9 +35,7 @@ const ProjectCard = ({ id, name, skills, status, repoName, headerImage }) => {
       <CardActions>
         <Grid container spacing={16} alignItems="center">
           <EditableSkills value={skills} name="skills" />
-          <Link to={`https://github.com/codefordenver/${repoName}`}>
-            GitHub
-          </Link>
+          <a href={`https://github.com/codefordenver/${repoName}`}>GitHub</a>
           <Grid item>{status && <span> Status: {status}</span>}</Grid>
         </Grid>
       </CardActions>


### PR DESCRIPTION
#### What does this PR do?

Right now trying to navigate to a github repo just appends that link onto the end of the base url:

<img width="558" alt="screen shot 2018-11-06 at 9 30 02 am" src="https://user-images.githubusercontent.com/5432102/48078428-abec2200-e1a6-11e8-8274-f2e79070b9b8.png">

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/3o7buazaauRBkOsUaQ/giphy.gif)
