### PR TITLE
Don't use PureComponent without actually measuring performance

### DIFF
--- a/src/forms/EditableMarkdown.tsx
+++ b/src/forms/EditableMarkdown.tsx
@@ -19,7 +19,7 @@ interface State {
   tabView: TabViews;
 }
 
-class EditableMarkdown extends React.PureComponent<Props, State> {
+class EditableMarkdown extends React.Component<Props, State> {
   state: State = {
     tabView: 'write'
   };

--- a/src/shared-components/LoadingIndicator.tsx
+++ b/src/shared-components/LoadingIndicator.tsx
@@ -13,7 +13,7 @@ interface State {
   isShown: boolean;
 }
 
-class LoadingIndicator extends React.PureComponent<Props, State> {
+class LoadingIndicator extends React.Component<Props, State> {
   timeoutId: number;
 
   constructor(props: Props) {

--- a/src/utils/withCreatePage.js
+++ b/src/utils/withCreatePage.js
@@ -23,7 +23,7 @@ export default function withCreatePage({ renameProps }) {
   };
 
   return WrappedComponent => {
-    class CreatePageWrapper extends React.PureComponent {
+    class CreatePageWrapper extends React.Component {
       static displayName = `WithCreatePage(${getDisplayName(
         WrappedComponent
       )})`;

--- a/src/utils/withEditPage.js
+++ b/src/utils/withEditPage.js
@@ -25,7 +25,7 @@ export default function withEditPage({ renameProps }) {
   };
 
   return WrappedComponent => {
-    class EditPageWrapper extends React.PureComponent {
+    class EditPageWrapper extends React.Component {
       static displayName = `WithEditPage(${getDisplayName(WrappedComponent)})`;
 
       state = {

--- a/src/utils/withViewPage.js
+++ b/src/utils/withViewPage.js
@@ -20,7 +20,7 @@ export default function withViewPage({ renameProps }) {
   };
 
   return WrappedComponent => {
-    class ViewPageWrapper extends React.PureComponent {
+    class ViewPageWrapper extends React.Component {
       static displayName = `WithViewPage(${getDisplayName(WrappedComponent)})`;
 
       render() {


### PR DESCRIPTION
#### What does this PR do?

Stops using PureComponent just because it seemed like a good idea without actually measuring. 

For this particular app I'm not sure if we have any cases where parent components clearly commonly render while child components don't need to rerender, so using PureComponent is probably actually making things slightly slower because when React tries to rerender one of these PureComponents it will first check the shallow equality of the props and then most of the time find that the component needs to be rerendered anyway causing extra unnecessary work.

It's possible they make things slightly more efficient in some cases, but we shouldn't just use them blindly and currently, I'm not aware of any performance concerns around rerenders so we could hold off on investigating that.

See this great blog post for context: https://cdb.reacttraining.com/react-inline-functions-and-performance-bdff784f5578

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/3oKIPvl6VJA7wHzIFa/giphy.gif)
