### PR TITLE
Add initial member since info to member profile

### DIFF
--- a/src/authenticated/member/Member.css
+++ b/src/authenticated/member/Member.css
@@ -28,6 +28,11 @@
   margin: 20px;
 }
 
+.Member-since {
+  color: #999;
+  font-size: 0.8rem;
+}
+
 .Member-pic {
   justify-content: center;
   display: flex;

--- a/src/authenticated/member/MemberProfile.tsx
+++ b/src/authenticated/member/MemberProfile.tsx
@@ -25,6 +25,7 @@ const MemberProfile: React.SFC<MemberProfileProps> = ({
     return <LoadingIndicator />;
   }
   const {
+    createdAt,
     picture,
     name,
     description,
@@ -60,6 +61,9 @@ const MemberProfile: React.SFC<MemberProfileProps> = ({
                 {...commonProps}
               />
             </h2>
+            <div className="Member-since">
+              Member since: {new Date(createdAt).toLocaleDateString()}
+            </div>
             <EditableMarkdown
               value={description}
               label="Description"

--- a/src/generated-models.tsx
+++ b/src/generated-models.tsx
@@ -1897,6 +1897,8 @@ export type MemberProfileFragmentFragment = {
 
   id: string;
 
+  createdAt: DateTime;
+
   picture: Maybe<string>;
 
   name: Maybe<string>;
@@ -1907,7 +1909,7 @@ export type MemberProfileFragmentFragment = {
 
   flowdockName: Maybe<string>;
 
-  role: UserRole | null;
+  role: Maybe<UserRole>;
 
   email: string;
 
@@ -2002,6 +2004,7 @@ import gql from 'graphql-tag';
 export const MemberProfileFragmentFragmentDoc = gql`
   fragment MemberProfileFragment on User {
     id
+    createdAt
     picture
     name
     description

--- a/src/graphql/MemberProfileFragment.graphql
+++ b/src/graphql/MemberProfileFragment.graphql
@@ -1,5 +1,6 @@
 fragment MemberProfileFragment on User {
   id
+  createdAt
   picture
   name
   description


### PR DESCRIPTION
This PR closes #34 

#### What does this PR do?

Adds a member since section to the member profile page

This would have been useful recently when I was trying to track down which user was which between two people that had the same name.

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/xT8qBtNxYcuUa6c1dm/giphy.gif)
